### PR TITLE
Add a driver implementation which uses a bloom filter to check passwords

### DIFF
--- a/drivers/bloompw/bloom.go
+++ b/drivers/bloompw/bloom.go
@@ -1,0 +1,41 @@
+// Copyright 2015, Mike Houston, see LICENSE for details.
+package bloompw
+
+import (
+	"github.com/AndreasBriese/bbloom"
+)
+
+type BloomPW struct {
+	Filter *bbloom.Bloom
+}
+
+// New will return a new Database interface that stores entries in
+// a bloom filter
+func New(filter *bbloom.Bloom) (*BloomPW, error) {
+	b := &BloomPW{Filter: filter}
+
+	return b, nil
+}
+
+// Has satisfies the password.DB interface
+func (b BloomPW) Has(s string) (bool, error) {
+	return b.Filter.Has([]byte(s)), nil
+}
+
+// Has satisfies the password.DbWriter interface.
+// It writes a single password to the database
+func (b BloomPW) Add(s string) error {
+	b.Filter.Add([]byte(s))
+	return nil
+}
+
+// AddMultiple satisfies the password.BulkWriter interface.
+// It writes a number of passwords to the database
+func (b BloomPW) AddMultiple(s []string) error {
+	for _, v := range s {
+		if err := b.Add(v); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/drivers/bloompw/bloom_test.go
+++ b/drivers/bloompw/bloom_test.go
@@ -1,0 +1,25 @@
+// Copyright 2015, Mike Houston, see LICENSE for details.
+
+package bloompw
+
+import (
+	"testing"
+
+	"github.com/AndreasBriese/bbloom"
+	"github.com/klauspost/password/drivers"
+)
+
+// Test a bloom database
+func TestBloom(t *testing.T) {
+	// create a bloom filter for 65536 items and 0.001 % wrong-positive ratio
+	filter := bbloom.New(float64(1<<16), float64(0.00001))
+
+	bloom, err := New(&filter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = drivers.TestDriver(bloom)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This was my immediate thought when reading your blog. Since you're not really that worried if you get a few false positives, and you don't care what the passwords actually are, a bloom filter would allow you to condense the data considerably.

With a 1% false positive rate, you could theoretically condense your 1 billion word 'paranoid' dictionary to 1.3GB:
http://www.wolframalpha.com/input/?i=%281.44+*+log2%281%2F.01%29+*+1123000000%29%2F8+bytes+in+megabytes

Ideally you would want a memory-mapped implementation of the bloom filter to avoid needing to keep the whole filter in RAM. https://github.com/bitly/dablooms does have memory mapping, but is a counting filter and uses 4x as much space.
